### PR TITLE
New: Redirect Swagger requests to backend

### DIFF
--- a/data/router/usr/local/etc/haproxy/haproxy.cfg
+++ b/data/router/usr/local/etc/haproxy/haproxy.cfg
@@ -63,7 +63,7 @@ frontend http-in-ssl
         errorfile 503 /usr/local/etc/haproxy/errors/503-custom.http
 
         # Actuator requests points to backend service
-        acl host_dev-huelladigital_backend path -i -m beg /actuator path -i -m beg /api/
+        acl host_dev-huelladigital_backend path -i -m beg /actuator path -i -m beg /api/ path -i -m beg /swagger-ui/ path -i -m beg /v3/api-docs/
         use_backend dev-huelladigital_backend if host_dev-huelladigital_backend
 
         # Default haproxy backend point to frontend service


### PR DESCRIPTION
This would redirect Swagger requests to the backend service. Still missing basic auth on those endpoints